### PR TITLE
Changes for using inputs on UniPi1.1

### DIFF
--- a/custom_components/unipi_neuron/binary_sensor.py
+++ b/custom_components/unipi_neuron/binary_sensor.py
@@ -29,7 +29,7 @@ DEVICE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_DEVICE): vol.Any("input"),
-        vol.Required(CONF_PORT): cv.matches_regex(r"^[1-3]_[0-1][0-9]"),
+        vol.Required(CONF_PORT): cv.matches_regex(r"^[1-3]_[0-1][0-9]|[1-12]"),
     }
 )
 


### PR DESCRIPTION
Hi marko,

Thx for integration !

The input port number scheme differs for UniPi 1.1 ("/input/1") from Neuron ("/input/1_01").
I add |[1-12] for regex for using inputs on UniPi1.1, work fine on my side !

Thx