### PR TITLE
binary sensor: add matches for the unipi1.1

### DIFF
--- a/custom_components/unipi_neuron/binary_sensor.py
+++ b/custom_components/unipi_neuron/binary_sensor.py
@@ -29,7 +29,7 @@ DEVICE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_DEVICE): vol.Any("input", "di"),
-        vol.Required(CONF_PORT): cv.matches_regex(r"^[1-9]_[0-1][0-9]"),
+        vol.Required(CONF_PORT): cv.matches_regex(r"^[1-9]_[0-1][0-9]$|^1[0-2]$|^[1-9]$"),
     }
 )
 


### PR DESCRIPTION
the 1.1 has its inputs named 1 -> 12 without leading zeros